### PR TITLE
Add basic prison level and generator script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ data_*/
 /addons/fp_controller
 /assets
 /ref
+__pycache__/

--- a/game_data.json
+++ b/game_data.json
@@ -1,0 +1,43 @@
+{
+  "contraband": [
+    {
+      "name": "Toothbrush Shiv",
+      "components": [
+        "Toothbrush",
+        "Razor Blade"
+      ],
+      "risk": 5
+    },
+    {
+      "name": "Foil Gum Keycard",
+      "components": [
+        "Gum",
+        "Foil",
+        "Ink Pen"
+      ],
+      "risk": 3
+    },
+    {
+      "name": "Battery Lockpick",
+      "components": [
+        "AA Battery",
+        "Paperclip"
+      ],
+      "risk": 2
+    }
+  ],
+  "tiles": [
+    {
+      "id": "dirty_cell",
+      "description": "A dirty concrete floor"
+    },
+    {
+      "id": "vent_duct",
+      "description": "Rusty air duct cover"
+    },
+    {
+      "id": "guard_room",
+      "description": "Locked guard surveillance room"
+    }
+  ]
+}

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Cogito"
-run/main_scene="res://addons/cogito/DemoScenes/COGITO_0_MainMenu.tscn"
+run/main_scene="res://scenes/prison_block_a.tscn"
 config/features=PackedStringArray("4.4", "Forward Plus")
 run/max_fps=120
 boot_splash/fullsize=false
@@ -20,12 +20,10 @@ config/icon="res://addons/cogito/COGITO_icon.png"
 
 [autoload]
 
-Audio="*res://addons/quick_audio/./Audio.gd"
 CogitoGlobals="*res://addons/cogito/cogito_globals.gd"
 CogitoSceneManager="*res://addons/cogito/SceneManagement/cogito_scene_manager.gd"
 CogitoQuestManager="*res://addons/cogito/QuestSystem/cogito_quest_manager.gd"
 MenuTemplateManager="*res://addons/cogito/EasyMenus/Nodes/menu_template_manager.tscn"
-InputHelper="*res://addons/input_helper/input_helper.gd"
 
 [display]
 

--- a/scenes/contraband_item.tscn
+++ b/scenes/contraband_item.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=4]
+
+[ext_resource type="Script" path="res://scenes/scripts/contraband_item.gd" id="1"]
+
+[node name="ContrabandItem" type="Node3D"]
+script = ExtResource("1")
+
+[node name="Mesh" type="CubeMesh" parent="."]
+
+[node name="Area3D" type="Area3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = BoxShape3D.new()
+

--- a/scenes/escape_success.tscn
+++ b/scenes/escape_success.tscn
@@ -1,0 +1,4 @@
+[gd_scene load_steps=1 format=4]
+
+[node name="EscapeSuccess" type="Node"]
+

--- a/scenes/escape_zone.tscn
+++ b/scenes/escape_zone.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource type="Script" path="res://scenes/scripts/escape_zone.gd" id="1"]
+
+[node name="EscapeZone" type="Area3D"]
+script = ExtResource("1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = BoxShape3D.new()
+

--- a/scenes/guard_npc.tscn
+++ b/scenes/guard_npc.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=4]
+
+[ext_resource type="Script" path="res://addons/cogito/Enemies/cogito_basic_enemy.gd" id="1"]
+
+[node name="GuardNPC" type="CharacterBody3D"]
+script = ExtResource("1")
+
+[node name="Capsule" type="CapsuleMesh" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = CapsuleShape3D.new()
+

--- a/scenes/prison_block_a.tscn
+++ b/scenes/prison_block_a.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=5 format=4]
+
+[ext_resource type="Script" path="res://addons/cogito/SceneManagement/cogito_scene.gd" id="1"]
+[ext_resource type="PackedScene" path="res://addons/cogito/PackedScenes/cogito_player.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/guard_npc.tscn" id="3"]
+[ext_resource type="PackedScene" path="res://scenes/contraband_item.tscn" id="4"]
+[ext_resource type="PackedScene" path="res://scenes/escape_zone.tscn" id="5"]
+
+[node name="PrisonBlockA" type="Node3D"]
+script = ExtResource("1")
+
+[node name="PlayerSpawn" parent="." instance=ExtResource("2")]
+transform = Transform3D(1,0,0,0,1,0,0,0,1,0,0,0)
+
+[node name="Guard" parent="." instance=ExtResource("3")]
+transform = Transform3D(1,0,0,0,1,0,0,0,1,5,0,5)
+
+[node name="Contraband" parent="." instance=ExtResource("4")]
+transform = Transform3D(1,0,0,0,1,0,0,0,1,2,0,2)
+
+[node name="Escape" parent="." instance=ExtResource("5")]
+transform = Transform3D(1,0,0,0,1,0,0,0,1,-5,0,-5)
+

--- a/scenes/scripts/contraband_item.gd
+++ b/scenes/scripts/contraband_item.gd
@@ -1,0 +1,11 @@
+extends Node3D
+@onready var pickup_area = $Area3D
+
+func _ready():
+    pickup_area.body_entered.connect(_on_pickup)
+
+func _on_pickup(body):
+    if body.name == "CogitoPlayer":
+        if body.has_method("add_to_inventory"):
+            body.add_to_inventory("Toothbrush Shiv")
+        queue_free()

--- a/scenes/scripts/escape_zone.gd
+++ b/scenes/scripts/escape_zone.gd
@@ -1,0 +1,11 @@
+extends Area3D
+
+func _ready():
+    self.body_entered.connect(_on_area_entered)
+
+func _on_area_entered(body):
+    if body.name == "CogitoPlayer":
+        if body.has_method("has_item") and body.has_item("Keycard"):
+            print("ESCAPE!")
+            get_tree().change_scene_to_file("res://scenes/escape_success.tscn")
+

--- a/scripts/generate_game_data.py
+++ b/scripts/generate_game_data.py
@@ -1,0 +1,26 @@
+import random, json
+
+contraband_items = [
+    ("Toothbrush Shiv", ["Toothbrush", "Razor Blade"]),
+    ("Foil Gum Keycard", ["Gum", "Foil", "Ink Pen"]),
+    ("Battery Lockpick", ["AA Battery", "Paperclip"])
+]
+
+tiles = [
+    ("dirty_cell", "A dirty concrete floor"),
+    ("vent_duct", "Rusty air duct cover"),
+    ("guard_room", "Locked guard surveillance room")
+]
+
+output = {
+    "contraband": [
+        {"name": c[0], "components": c[1], "risk": random.randint(1, 10)}
+        for c in contraband_items
+    ],
+    "tiles": [
+        {"id": t[0], "description": t[1]} for t in tiles
+    ]
+}
+
+with open("game_data.json", "w") as f:
+    json.dump(output, f, indent=2)


### PR DESCRIPTION
## Summary
- set `prison_block_a.tscn` as the main scene
- create simple prison level scene with player, guard, contraband and escape zone
- add guard, contraband, escape zone scenes and scripts
- add python script to generate contraband/tile data
- track generated `game_data.json`
- ignore python `__pycache__` directories
- remove redundant autoload entries in project settings

## Testing
- `python3 -m py_compile scripts/generate_game_data.py`


------
https://chatgpt.com/codex/tasks/task_e_684223b2406c83289477b99a4e986667